### PR TITLE
update from upstream

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -23,6 +23,7 @@ disallowed-names = ["bar", "baz", "e", "err", "foo", "ok", "quux"]
 disallowed-types = [
     { path = "std::collections::HashMap", replacement = "hashbrown::HashMap", reason = "The standard library version sacrifices performance for HashDos resistance, which should be chosen explicitly" },
     { path = "std::collections::HashSet", replacement = "hashbrown::HashSet", reason = "The standard library version sacrifices performance for HashDos resistance, which should be chosen explicitly" },
+    { path = "time::Duration", replacement = "time::SignedDuration", reason = "time::Duration is deprecated" },
 ]
 enforced-import-renames = [
     { path = "serde_json::from_slice", rename = "from_json_slice" },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "type": "module",
     "packageManager": "pnpm@11.19.0+sha512.7881f3ed590d472c4a955e2b88b2121791116066dcc88cbca3849ec9b60f1bbaa6d2ccb221fa91da4e1c65bef2bcbe379365aea7ac539c7bf86dedc3a1b22dce",
     "engines": {
-        "node": "26.5.1",
+        "node": "26.6.0",
         "pnpm": "11.19.0"
     },
     "scripts": {


### PR DESCRIPTION
- **chore(deps): update node.js to v26.6.0**
- **chore: ban `time::Duration`, it's deprecated**
